### PR TITLE
这里的路径应该是"web/admin-client"？

### DIFF
--- a/docs/src/guide/deploy/docker.md
+++ b/docs/src/guide/deploy/docker.md
@@ -95,7 +95,7 @@ const maxImgSize = 5;//上传图片最大大小(单位M)
 const maxVideoSize = 500;//上传视频最大大小(单位M)
 ```
 #### 2. 构建项目
-回到`web/web-client`目录下，使用一下命令构建项目
+回到`web/admin-client`目录下，使用一下命令构建项目
 ```sh
 # 先安装项目依赖
 yarn install


### PR DESCRIPTION
那个我有个问题请教一下大佬，我按照教程在docker部署新项目，后台显示前端和后端容器皆运行正常，API的网址点进去也是正常显示404，但是前端客户端和管理端一个显示500一个打不开显示空白，但路径能正常跳转，我已经尝试过好几次部署换了好几次环境了，有没有什么解决办法QWQ

系统 ubuntu 20.04
Nodejs 版本 20.15.0