### PR TITLE
fix: 修正DeleteAnnounce函数中的错误提示信息

### DIFF
--- a/server/internal/service/msg_announce.go
+++ b/server/internal/service/msg_announce.go
@@ -30,7 +30,7 @@ func AddAnnounce(ctx *gin.Context, addAnnounceReq dto.AddAnnounceReq) error {
 func DeleteAnnounce(ctx *gin.Context, id uint) error {
 	if err := global.Mysql.Where("id = ?", id).Delete(&model.Announce{}).Error; err != nil {
 		utils.ErrorLog("删除公告失败", "announce", err.Error())
-		return errors.New("删除角色失败")
+		return errors.New("删除公告失败")
 	}
 
 	return nil


### PR DESCRIPTION
将"删除角色失败" 改为 "删除公告失败"