### PR TITLE
fix: 修复深色主题下的页面样式一致性问题

### DIFF
--- a/web/admin-client/src/utils/format.ts
+++ b/web/admin-client/src/utils/format.ts
@@ -20,7 +20,7 @@ export const formatDate = (time: string) => {
 }
 
 export const formatTime = (time: string | Date) => {
-  return moment(time).format("YYYY-MM-DD hh:mm:ss")
+  return moment(time).format("YYYY-MM-DD HH:mm:ss")
 }
 
 export const formatRelativeTime = (timeStr: string | Date) => {

--- a/web/web-client/src/assets/styles/article-html.scss
+++ b/web/web-client/src/assets/styles/article-html.scss
@@ -4,10 +4,54 @@
   padding: 0 10px;
   white-space: pre-wrap;
   overflow: hidden;
+  color: var(--font-primary-1);
 
   img {
     max-width: 100%;
   }
+}
+
+/* 深色主题下的编辑器内容样式 */
+.dark .w-e-text {
+  background-color: var(--bg-elev-1) !important;
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container {
+  background-color: var(--bg-elev-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] {
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] p {
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] h1,
+.dark .w-e-text-container [data-slate-editor] h2,
+.dark .w-e-text-container [data-slate-editor] h3,
+.dark .w-e-text-container [data-slate-editor] h4,
+.dark .w-e-text-container [data-slate-editor] h5,
+.dark .w-e-text-container [data-slate-editor] h6 {
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] strong {
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] em {
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] u {
+  color: var(--font-primary-1) !important;
+}
+
+.dark .w-e-text-container [data-slate-editor] a {
+  color: var(--primary-color) !important;
 }
 
 .seowhy {

--- a/web/web-client/src/pages/article/[id].vue
+++ b/web/web-client/src/pages/article/[id].vue
@@ -111,7 +111,7 @@ onBeforeMount(() => {
   position: relative;
   min-height: 100vh;
   padding-top: 76px;
-  background-color: #f6f7f9;
+  background-color: var(--bg-page);
 
   .header {
     position: fixed;
@@ -128,7 +128,7 @@ onBeforeMount(() => {
 }
 
 .article-content {
-  background-color: #fff;
+  background-color: var(--bg-elev-1);
   border-radius: 4px;
   padding: 20px 40px 40px;
 
@@ -139,7 +139,7 @@ onBeforeMount(() => {
     .title {
       min-height: 39px;
       font-size: 28px;
-      color: #222;
+      color: var(--font-primary-1);
       margin-bottom: 16px;
       font-weight: 700;
       line-height: 1.4;
@@ -147,7 +147,7 @@ onBeforeMount(() => {
 
     .article-read-panel {
       margin-bottom: 20px;
-      color: #999;
+      color: var(--font-primary-3);
 
       .article-read-info {
         font-weight: 400;
@@ -169,14 +169,14 @@ onBeforeMount(() => {
 .title-line {
   height: 1px;
   width: 100%;
-  background: hsla(0, 0%, 59.2%, .21);
+  background: var(--border-color);
   margin-bottom: 20px;
 }
 
 .comment-list {
   margin-top: 20px;
   padding: 20px;
-  background-color: #fff;
+  background-color: var(--bg-elev-1);
 }
 
 @media (max-width: 1400px) {

--- a/web/web-client/src/pages/article/components/ArchiveInfo.vue
+++ b/web/web-client/src/pages/article/components/ArchiveInfo.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="side-bar">
     <div class="side-toolbar">
-      <div class="toolbar-item">
-        <el-icon :class="[likeAnimation, archive.hasLike ? 'active' : 'icon']" @click="likeClick">
+      <div class="toolbar-item" @click="likeClick">
+        <el-icon :class="[likeAnimation, archive.hasLike ? 'active' : 'icon']">
           <like-icon></like-icon>
         </el-icon>
       </div>
-      <div class="toolbar-item">
-        <el-icon :class="[collectAnimation, archive.hasCollect ? 'active' : 'icon']" @click="collectClick">
+      <div class="toolbar-item" @click="collectClick">
+        <el-icon :class="[collectAnimation, archive.hasCollect ? 'active' : 'icon']">
           <collect-icon></collect-icon>
         </el-icon>
       </div>
-      <div class="toolbar-item">
-        <el-icon @click="scrollToComment">
+      <div class="toolbar-item" @click="scrollToComment">
+        <el-icon>
           <comment-fill-icon></comment-fill-icon>
         </el-icon>
       </div>

--- a/web/web-client/src/pages/article/components/ArchiveInfo.vue
+++ b/web/web-client/src/pages/article/components/ArchiveInfo.vue
@@ -111,8 +111,8 @@ onBeforeMount(async () => {
   .side-toolbar {
     .toolbar-item {
       position: relative;
-      color: #8a919f;
-      background: #fff;
+      color: var(--font-primary-3);
+      background: var(--bg-elev-1);
       display: flex;
       flex-direction: column;
       align-items: center;

--- a/web/web-client/src/pages/article/components/AuthorCard.vue
+++ b/web/web-client/src/pages/article/components/AuthorCard.vue
@@ -90,7 +90,7 @@ onBeforeMount(() => {
       .up-name {
         font-size: 14px;
         max-width: 150px;
-        color: #212121;
+        color: var(--font-primary-1);
         line-height: 23px;
         height: 23px;
         text-overflow: ellipsis;
@@ -103,7 +103,7 @@ onBeforeMount(() => {
       .up-sign {
         display: block;
         font-size: 13px;
-        color: #999;
+        color: var(--font-primary-3);
         line-height: 20px;
       }
     }

--- a/web/web-client/src/pages/article/components/CommentList.vue
+++ b/web/web-client/src/pages/article/components/CommentList.vue
@@ -327,7 +327,7 @@ onBeforeUnmount(() => {
       align-items: center;
 
       .nav-title-text {
-        color: #18191c;
+        color: var(--font-primary-1);
         font-weight: 500;
       }
 
@@ -335,7 +335,7 @@ onBeforeUnmount(() => {
         font-size: 13px;
         margin: 0 36px 0 6px;
         font-weight: 400;
-        color: #9499a0;
+        color: var(--font-primary-3);
       }
     }
   }
@@ -417,7 +417,7 @@ onBeforeUnmount(() => {
         font-weight: 500;
         margin-right: 5px;
         line-height: 20px;
-        color: #61666d;
+        color: var(--font-primary-2);
         cursor: pointer;
       }
     }
@@ -433,7 +433,7 @@ onBeforeUnmount(() => {
       font-weight: 400;
 
       .comment-content {
-        color: #18191c;
+        color: var(--font-primary-1);
         overflow: hidden;
         word-wrap: break-word;
         word-break: break-word;
@@ -451,7 +451,7 @@ onBeforeUnmount(() => {
       height: 24px;
       margin-top: 2px;
       font-size: 13px;
-      color: #9499a0;
+      color: var(--font-primary-3);
       font-weight: 400;
 
       .comment-time {
@@ -496,13 +496,13 @@ onBeforeUnmount(() => {
         line-height: 24px;
         font-weight: 500;
         margin-right: 5px;
-        color: #61666d;
+        color: var(--font-primary-2);
       }
     }
 
     .reply-content-container {
       .reply-content {
-        color: #18191c;
+        color: var(--font-primary-1);
         overflow: hidden;
         word-wrap: break-word;
         word-break: break-word;
@@ -519,7 +519,7 @@ onBeforeUnmount(() => {
       height: 24px;
       margin-top: 2px;
       font-size: 13px;
-      color: #9499a0;
+      color: var(--font-primary-3);
       font-weight: 400;
 
       .reply-time {
@@ -552,7 +552,7 @@ onBeforeUnmount(() => {
 
 .bottom-line {
   margin-top: 14px;
-  border-bottom: 1px solid #e3e5e7;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .at {
@@ -584,11 +584,11 @@ onBeforeUnmount(() => {
 }
 
 .btn-disabled {
-  color: #9499a0 !important;
+  color: var(--font-primary-3) !important;
   cursor: not-allowed !important;
 
   &:hover {
-    color: #9499a0 !important;
+    color: var(--font-primary-3) !important;
   }
 }
 

--- a/web/web-client/src/pages/article/list.vue
+++ b/web/web-client/src/pages/article/list.vue
@@ -98,7 +98,7 @@ onBeforeUnmount(() => {
   min-width: 1000px;
   overflow: hidden;
   min-height: 100vh;
-  background-color: #f2f3f5;
+  background-color: var(--bg-page);
 
 
   .home-header {
@@ -106,7 +106,7 @@ onBeforeUnmount(() => {
     top: 0;
     width: 100%;
     z-index: 999;
-    background-color: #fff;
+    background-color: var(--bg-elev-1);
   }
 }
 
@@ -145,7 +145,7 @@ onBeforeUnmount(() => {
   width: 100%;
   margin: 0;
   padding: 12px 0;
-  background-color: #fff;
+  background-color: var(--bg-elev-1);
 
   .article-item {
     height: 110px;
@@ -157,7 +157,7 @@ onBeforeUnmount(() => {
 .content-wrapper {
   display: flex;
   padding-bottom: 12px;
-  border-bottom: 1px solid rgba(228, 230, 235, 0.5);
+  border-bottom: 1px solid var(--border-color);
   width: 100%;
   margin-top: 2px;
 
@@ -170,7 +170,7 @@ onBeforeUnmount(() => {
       font-weight: 600;
       font-size: 16px;
       line-height: 24px;
-      color: #252933;
+      color: var(--font-primary-1);
       width: 100%;
       display: -webkit-box;
       overflow: hidden;
@@ -183,7 +183,7 @@ onBeforeUnmount(() => {
       min-height: 44px;
       margin-bottom: 4px;
       font-weight: 400;
-      color: #8a919f;
+      color: var(--font-primary-3);
       font-size: 13px;
       line-height: 22px;
       display: -webkit-box;
@@ -213,7 +213,7 @@ onBeforeUnmount(() => {
           margin-right: 24px;
           font-size: 13px;
           line-height: 20px;
-          color: #8a919f;
+          color: var(--font-primary-3);
 
           span {
             height: 16px;
@@ -231,7 +231,7 @@ onBeforeUnmount(() => {
         align-items: center;
 
         .tag {
-          background-color: #f2f3f5;
+          background-color: var(--fill-1);
           padding: 0 6px;
           border-radius: 2px;
           max-width: 76px;

--- a/web/web-client/src/pages/partition/[partition].vue
+++ b/web/web-client/src/pages/partition/[partition].vue
@@ -91,7 +91,7 @@ onBeforeUnmount(() => {
     top: 0;
     width: 100%;
     z-index: 999;
-    background-color: #fff;
+    background-color: var(--bg-elev-1);
   }
 }
 
@@ -104,7 +104,7 @@ onBeforeUnmount(() => {
     height: 100%;
     width: 220px;
     z-index: 1;
-    background-color: #fff;
+    background-color: var(--bg-elev-1);
     transition: width .25s;
   }
 

--- a/web/web-client/src/pages/upload/article-manage.vue
+++ b/web/web-client/src/pages/upload/article-manage.vue
@@ -288,13 +288,13 @@ onBeforeMount(() => {
         align-items: center;
 
         .tag {
-          background-color: #f2f3f5;
+          background-color: var(--fill-1);
           padding: 0 6px;
           border-radius: 2px;
           max-width: 76px;
           box-sizing: border-box;
           margin-left: 6px;
-          color: #8a919f;
+          color: var(--font-primary-3);
           text-overflow: ellipsis;
           overflow: hidden;
           white-space: nowrap;
@@ -334,13 +334,13 @@ onBeforeMount(() => {
 
   .delete-dialog-title {
     font-size: 16px;
-    color: #1f2328;
+    color: var(--font-primary-1);
     text-align: center;
     margin: 20px 0;
   }
 
   .delete-dialog-desc {
-    color: #666;
+    color: var(--font-primary-3);
     font-size: 13px;
     text-align: center;
 

--- a/web/web-client/src/pages/video/components/CommentList.vue
+++ b/web/web-client/src/pages/video/components/CommentList.vue
@@ -558,7 +558,7 @@ onBeforeUnmount(() => {
 
 .bottom-line {
   margin-top: 14px;
-  border-bottom: 1px solid #e3e5e7;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .at {


### PR DESCRIPTION
### 修改前

专栏页

<img width="2559" height="730" alt="image" src="https://github.com/user-attachments/assets/ad9db63c-30b9-445c-9947-6fa20947ec7e" />

分区页
<img width="2534" height="806" alt="image" src="https://github.com/user-attachments/assets/84b8959e-0f4b-4fae-8786-c7eb7e0967a2" />


### 修改后

专栏页

<img width="2547" height="608" alt="image" src="https://github.com/user-attachments/assets/9e93599d-31e7-497c-85d7-64fedd29922e" />

分区页

<img width="2559" height="782" alt="image" src="https://github.com/user-attachments/assets/e5c101c7-dc46-4636-9d0d-321f128496b2" />


以及专栏内容页


